### PR TITLE
Shifted viper package from suggest to depends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,8 @@ biocViews: ExperimentData, Homo_sapiens_Data, Mus_musculus_Data
 Imports:
     dplyr,
     magrittr,
-    bcellViper
+    bcellViper,
+    viper
 Suggests:
     Biobase,
     BiocStyle,
@@ -54,5 +55,4 @@ Suggests:
     testthat (>= 2.1.0),
     tibble,
     tidyr,
-    utils,
-    viper
+    utils

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # dorothea 1.1.2 (2020-10-08)
 * Changed TF census from [TFclass](https://doi.org/10.1093/nar/gkx987) to the more recent version from [Lambert et al.](10.1016/j.cell.2018.01.029). Information of mode of regulation for each TF (activator, supressor, dual) is still taken from [Garcia-Alonso et al.](http://www.genome.org/cgi/doi/10.1101/gr.240663.118).
 * Updated deprecated gene symbols to their latest version with the limma package (version 3.44.3).
+* Shifted viper package from 'suggest' to 'depends' in the DESCRIPTION file.
 
 # dorothea 1.1.1 (2020-09-02)
 * Export df2regulon function


### PR DESCRIPTION
This ensures that viper is automatically installed when dorothea is installed